### PR TITLE
docs: restore README title to 'LuxDevHQ Data Engineering Course Guide'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LuxDevHQ Data Engineering Guide
+# LuxDevHQ Data Engineering Course Guide
 
 A beginner-friendly path through Data Engineering concepts, guided practice, and real-world projects from LuxDevHQ. Data Engineering is the work of collecting, cleaning, moving, storing, and serving trustworthy data so that analysts, applications, and businesses can use it.
 


### PR DESCRIPTION
### Motivation
- Restore the README heading to the requested course-focused title while preserving the existing beginner learning path, repository map, and course roadmap structure.

### Description
- Update the first line of `README.md` from `# LuxDevHQ Data Engineering Guide` to `# LuxDevHQ Data Engineering Course Guide` with no other content changes.

### Testing
- Ran automated validations which all passed: `python - <<'PY' ... PY` (README heading and relative-link validation), `git diff --check`, `git status --porcelain`, and `git show --stat --oneline --decorate HEAD`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82e13a6e04832ab6a6d2fb57ab850e)